### PR TITLE
Fix clone - Sockets cannot be clone, only streams

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -6,14 +6,11 @@ use async_std::{
 use futures::FutureExt;
 use futures::{future::BoxFuture, ready};
 use log::debug;
+use std::cmp::{max, min};
 use std::collections::VecDeque;
 use std::io::{ErrorKind, Result};
 use std::task::Poll;
 use std::time::{Duration, Instant};
-use std::{
-    cmp::{max, min},
-    sync::Arc,
-};
 
 use crate::error::SocketError;
 use crate::packet::*;
@@ -97,10 +94,10 @@ async fn take_address<A: ToSocketAddrs>(addr: A) -> Result<SocketAddr> {
 /// socket.close().await;
 /// }); }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct UtpSocket {
     /// The wrapped UDP socket
-    socket: Arc<UdpSocket>,
+    socket: UdpSocket,
 
     /// Remote peer
     connected_to: SocketAddr,
@@ -186,7 +183,7 @@ impl UtpSocket {
         let (receiver_id, sender_id) = generate_sequential_identifiers();
 
         UtpSocket {
-            socket: s.into(),
+            socket: s,
             connected_to: src,
             receiver_connection_id: receiver_id,
             sender_connection_id: sender_id,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -6,11 +6,14 @@ use async_std::{
 use futures::FutureExt;
 use futures::{future::BoxFuture, ready};
 use log::debug;
-use std::cmp::{max, min};
 use std::collections::VecDeque;
 use std::io::{ErrorKind, Result};
 use std::task::Poll;
 use std::time::{Duration, Instant};
+use std::{
+    cmp::{max, min},
+    sync::Arc,
+};
 
 use crate::error::SocketError;
 use crate::packet::*;
@@ -1193,9 +1196,10 @@ impl Drop for UtpSocket {
 ///     }
 /// # }); }
 /// ```
+#[derive(Clone)]
 pub struct UtpListener {
     /// The public facing UDP socket
-    socket: UdpSocket,
+    socket: Arc<UdpSocket>,
 }
 
 impl UtpListener {
@@ -1209,7 +1213,9 @@ impl UtpListener {
     /// If more than one valid address is specified, only the first will be used.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<UtpListener> {
         let socket = UdpSocket::bind(addr).await?;
-        Ok(UtpListener { socket })
+        Ok(UtpListener {
+            socket: socket.into(),
+        })
     }
 
     /// Accepts a new incoming connection from this listener.
@@ -2337,6 +2343,26 @@ mod test {
 
         assert!(listener.local_addr().is_ok());
         assert_eq!(listener.local_addr().unwrap(), addr);
+    }
+
+    #[async_std::test]
+    async fn test_listener_listener_clone() {
+        let addr = next_test_ip4();
+        let addr = addr.to_socket_addrs().unwrap().next().unwrap();
+
+        // setup listener and clone to be used on two tasks
+        let listener1 = UtpListener::bind(addr).await.unwrap();
+        let listener2 = listener1.clone();
+
+        task::spawn(async move { listener1.accept().await.unwrap() });
+        task::spawn(async move { listener2.accept().await.unwrap() });
+
+        // Connect twice - to each listerner
+        task::spawn(async move {
+            UtpSocket::connect(addr).await.unwrap();
+            UtpSocket::connect(addr).await.unwrap();
+        })
+        .await;
     }
 
     #[async_std::test]

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -147,3 +147,41 @@ async fn test_local_addr() {
     assert!(stream.local_addr().await.is_ok());
     assert_eq!(stream.local_addr().await.unwrap(), addr);
 }
+
+#[async_std::test]
+async fn test_clone() {
+    use std::net::ToSocketAddrs;
+
+    let addr = next_test_ip4();
+    let addr = addr.to_socket_addrs().unwrap().next().unwrap();
+    let response = task::spawn(async move {
+        let mut server = UtpStream::bind(addr).await.unwrap();
+        let mut response = Vec::with_capacity(6);
+
+        let mut buf = vec![0; 3];
+        server.read(&mut buf).await.unwrap();
+        response.append(&mut buf);
+
+        let mut buf = vec![0; 3];
+        server.read(&mut buf).await.unwrap();
+        response.append(&mut buf);
+
+        response
+    });
+
+    let mut client1 = UtpStream::connect(addr).await.unwrap();
+    let mut client2 = client1.clone();
+
+    task::spawn(async move {
+        client1.write(&[0, 1, 2]).await.unwrap();
+    })
+    .await;
+
+    task::spawn(async move {
+        client2.write(&[3, 4, 5]).await.unwrap();
+    })
+    .await;
+
+    let result = response.await;
+    assert_eq!(result, vec![0, 1, 2, 3, 4, 5]);
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -144,8 +144,8 @@ async fn test_local_addr() {
     let addr = addr.to_socket_addrs().unwrap().next().unwrap();
     let stream = UtpStream::bind(addr).await.unwrap();
 
-    assert!(stream.local_addr().await.is_ok());
-    assert_eq!(stream.local_addr().await.unwrap(), addr);
+    assert!(stream.local_addr().is_ok());
+    assert_eq!(stream.local_addr().unwrap(), addr);
 }
 
 #[async_std::test]


### PR DESCRIPTION
Each socket has a series of ids, and cloning them dont seem to work.

It works behind an `std::sync::Arc` tho, as seem on `UtpStream` - as the ids remain the same.